### PR TITLE
Specifies the python version tests should run on

### DIFF
--- a/.github/workflows/runs-tests-and-linter.yaml
+++ b/.github/workflows/runs-tests-and-linter.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8, 3.10"]
+        python-version: ["3.10.11"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The GH workflow will run tests and linters on python version: 3.10.11