### PR TITLE
Changes the docker image tag in the GH workflow

### DIFF
--- a/.github/workflows/build-and-push-dk-image.yaml
+++ b/.github/workflows/build-and-push-dk-image.yaml
@@ -29,10 +29,10 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: endurosat-assignment
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: latest
         run: |
-          echo '=== Building image ==='
+          echo '\n\n=== Building image ===\n\n'
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
-          echo '=== Pushing image to $REGISTRY/$REPOSITORY:$IMAGE_TAG ==='
+          echo '\n\n=== Pushing image ===\n\n'
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
-          echo '=== Image pushed ==='
+          echo '\n\n=== Image pushed ==='


### PR DESCRIPTION
use `latest` as tags for docker images.
need a static tag string for pulling images from ECR to ECS.